### PR TITLE
Fix: avoid nested event loop; run Application.run_polling() synchronously

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,6 @@ Initializes and runs the Telegram bot with search conversation functionality,
 proper error handling, and logging configuration including persistent file logging.
 """
 
-import asyncio
-import inspect
 import logging
 import tempfile
 from pathlib import Path
@@ -168,12 +166,9 @@ def create_application() -> Application:
     return app
 
 
-async def run_bot() -> None:
+def run_bot() -> None:
     """
-    Run the Telegram bot with polling (async wrapper).
-
-    Calls `Application.run_polling`. If the call returns an awaitable (e.g. when
-    patched in tests), await it; otherwise, proceed without awaiting.
+    Run the Telegram bot with polling (synchronous).
     """
     logger.info("Starting Telegram bot")
 
@@ -182,11 +177,7 @@ async def run_bot() -> None:
 
         logger.info("Bot starting with polling mode")
         try:
-            from typing import Any, cast
-
-            result: Any = cast(Any, app).run_polling(drop_pending_updates=True)
-            if inspect.isawaitable(result):
-                await result
+            app.run_polling(drop_pending_updates=True)
         except Conflict as e:
             logger.error(
                 "Polling conflict: %s. Likely another bot instance or service is polling this token.",
@@ -211,8 +202,8 @@ def main() -> None:
     This function does not return under normal circumstances.
     """
     try:
-        # Run the bot (async run)
-        asyncio.run(run_bot())
+        # Run the bot (synchronous run)
+        run_bot()
 
     except KeyboardInterrupt:
         print("\nBot stopped by user")


### PR DESCRIPTION
This PR fixes a production crash on Railway: 'This event loop is already running' / 'Cannot close a running event loop'.\n\nChanges:\n- Run PTB v20+  synchronously (it manages the loop).\n- Remove nested  from  to avoid double event loop.\n- Keep logging, error handling, and startup logs intact.\n\nValidation:\n- flake8 + mypy passed.\n- Unit tests passed (coverage ~84%).\n\nAfter merge, redeploy should start cleanly without event loop errors.